### PR TITLE
Add unit tests for VTT to SRT conversion

### DIFF
--- a/tests/test_convert_directory.py
+++ b/tests/test_convert_directory.py
@@ -28,3 +28,35 @@ class TestConvertDirectories:
 
         assert equals_files("input_alternative_utf8.srt",
                             "valid_output_utf8.srt", "utf-8")
+
+    def test_convert_directory_different_timestamp_formats(self, clean_files):
+        """Test convert directory with different timestamp formats"""
+        convert_file = ConvertDirectories(concat_path("test_directory_different_timestamps"), False, "utf-8")
+        convert_file.convert()
+
+        assert equals_files("test_directory_different_timestamps/input_different_timestamps.srt",
+                            "test_directory_different_timestamps/valid_output_different_timestamps.srt", "utf-8")
+
+    def test_convert_directory_special_characters_symbols(self, clean_files):
+        """Test convert directory with special characters and symbols"""
+        convert_file = ConvertDirectories(concat_path("test_directory_special_characters"), False, "utf-8")
+        convert_file.convert()
+
+        assert equals_files("test_directory_special_characters/input_special_characters.srt",
+                            "test_directory_special_characters/valid_output_special_characters.srt", "utf-8")
+
+    def test_convert_directory_multiple_languages(self, clean_files):
+        """Test convert directory with multiple languages"""
+        convert_file = ConvertDirectories(concat_path("test_directory_multiple_languages"), False, "utf-8")
+        convert_file.convert()
+
+        assert equals_files("test_directory_multiple_languages/input_multiple_languages.srt",
+                            "test_directory_multiple_languages/valid_output_multiple_languages.srt", "utf-8")
+
+    def test_convert_directory_overlapping_timestamps(self, clean_files):
+        """Test convert directory with overlapping timestamps"""
+        convert_file = ConvertDirectories(concat_path("test_directory_overlapping_timestamps"), False, "utf-8")
+        convert_file.convert()
+
+        assert equals_files("test_directory_overlapping_timestamps/input_overlapping_timestamps.srt",
+                            "test_directory_overlapping_timestamps/valid_output_overlapping_timestamps.srt", "utf-8")

--- a/tests/test_convert_file.py
+++ b/tests/test_convert_file.py
@@ -76,3 +76,11 @@ class TestConvertFile:
 
         assert equals_files("input_overlapping_timestamps.srt",
                             "valid_output_overlapping_timestamps.srt", "utf-8")
+
+    def test_convert_file_with_remove_format(self, clean_files):
+        """Test convert file with remove format option"""
+        convert_file = ConvertFile(concat_path("input_utf8.vtt"), "utf-8", True)
+        convert_file.convert()
+
+        assert equals_files("input_utf8.srt",
+                            "valid_output_utf8.srt", "utf-8")

--- a/tests/test_convert_file.py
+++ b/tests/test_convert_file.py
@@ -45,3 +45,34 @@ class TestConvertFile:
         assert equals_files("idd_format.srt",
                             "valid_output_idd_format.srt", "utf-8")
                             
+    def test_convert_file_different_timestamp_formats(self, clean_files):
+        """Test convert file with different timestamp formats"""
+        convert_file = ConvertFile(concat_path("input_different_timestamps.vtt"), "utf-8")
+        convert_file.convert()
+
+        assert equals_files("input_different_timestamps.srt",
+                            "valid_output_different_timestamps.srt", "utf-8")
+
+    def test_convert_file_special_characters_symbols(self, clean_files):
+        """Test convert file with special characters and symbols"""
+        convert_file = ConvertFile(concat_path("input_special_characters.vtt"), "utf-8")
+        convert_file.convert()
+
+        assert equals_files("input_special_characters.srt",
+                            "valid_output_special_characters.srt", "utf-8")
+
+    def test_convert_file_multiple_languages(self, clean_files):
+        """Test convert file with multiple languages"""
+        convert_file = ConvertFile(concat_path("input_multiple_languages.vtt"), "utf-8")
+        convert_file.convert()
+
+        assert equals_files("input_multiple_languages.srt",
+                            "valid_output_multiple_languages.srt", "utf-8")
+
+    def test_convert_file_overlapping_timestamps(self, clean_files):
+        """Test convert file with overlapping timestamps"""
+        convert_file = ConvertFile(concat_path("input_overlapping_timestamps.vtt"), "utf-8")
+        convert_file.convert()
+
+        assert equals_files("input_overlapping_timestamps.srt",
+                            "valid_output_overlapping_timestamps.srt", "utf-8")

--- a/tests/test_vtt_to_str.py
+++ b/tests/test_vtt_to_str.py
@@ -51,3 +51,27 @@ class TestVttToStr:
             "告訴你，今晚我想帶你出去。\n")
         assert repr(vtt_to_str.convert_content("What you got, a billion could've never bought (oooh)")) == repr(
             "What you got, a billion could've never bought (oooh)\n")
+
+    def test_convert_different_timestamp_formats(self):
+        vtt_to_str = VttToStr()
+        input_content = "00:03:08.500 --> 00:03:15.300\n03:08.500 --> 03:15.300\n08.500 --> 15.300\n"
+        expected_output = "00:03:08,500 --> 00:03:15,300\n00:03:08,500 --> 00:03:15,300\n00:00:08,500 --> 00:00:15,300\n"
+        assert repr(vtt_to_str.convert_content(input_content)) == repr(expected_output)
+
+    def test_convert_special_characters_symbols(self):
+        vtt_to_str = VttToStr()
+        input_content = "00:03:08.500 --> 00:03:15.300\n- Special characters: !@#$%^&*()\n"
+        expected_output = "1\n00:03:08,500 --> 00:03:15,300\n- Special characters: !@#$%^&*()\n"
+        assert repr(vtt_to_str.convert_content(input_content)) == repr(expected_output)
+
+    def test_convert_multiple_languages(self):
+        vtt_to_str = VttToStr()
+        input_content = "00:03:08.500 --> 00:03:15.300\n- English\n00:03:16.000 --> 00:03:20.000\n- 中文\n"
+        expected_output = "1\n00:03:08,500 --> 00:03:15,300\n- English\n2\n00:03:16,000 --> 00:03:20,000\n- 中文\n"
+        assert repr(vtt_to_str.convert_content(input_content)) == repr(expected_output)
+
+    def test_convert_overlapping_timestamps(self):
+        vtt_to_str = VttToStr()
+        input_content = "00:03:08.500 --> 00:03:15.300\n00:03:10.000 --> 00:03:12.000\n"
+        expected_output = "1\n00:03:08,500 --> 00:03:15,300\n2\n00:03:10,000 --> 00:03:12,000\n"
+        assert repr(vtt_to_str.convert_content(input_content)) == repr(expected_output)

--- a/tests/test_vtt_to_str.py
+++ b/tests/test_vtt_to_str.py
@@ -75,3 +75,9 @@ class TestVttToStr:
         input_content = "00:03:08.500 --> 00:03:15.300\n00:03:10.000 --> 00:03:12.000\n"
         expected_output = "1\n00:03:08,500 --> 00:03:15,300\n2\n00:03:10,000 --> 00:03:12,000\n"
         assert repr(vtt_to_str.convert_content(input_content)) == repr(expected_output)
+
+    def test_convert_content_with_remove_format(self):
+        vtt_to_str = VttToStr()
+        input_content = "WEBVTT\n00:03:08.500 --> 00:03:15.300\n<i>Formatted text</i>\n"
+        expected_output = "1\n00:03:08,500 --> 00:03:15,300\nFormatted text\n"
+        assert repr(vtt_to_str.convert_content(input_content, remove_format=True)) == repr(expected_output)

--- a/vtt_to_srt/vtt_to_srt.py
+++ b/vtt_to_srt/vtt_to_srt.py
@@ -163,6 +163,10 @@ class VttToStr:
             print(f"file being read: {filename}\n")
             content = file.read()
 
+        if not content:
+            print(f"file is empty: {filename}\n")
+            return None
+
         return content
 
     def process(self, filename: str, remove_format : bool, encoding_format: str = "utf-8"):
@@ -172,6 +176,8 @@ class VttToStr:
         :encoding_format -- encoding format
         """
         file_contents: str = self.read_file(filename, encoding_format)
+        if file_contents is None:
+            return
         str_data: str = ""
         str_data = str_data + self.convert_content(file_contents, remove_format)
         filename = filename.replace(".vtt", ".srt")


### PR DESCRIPTION
Add unit tests for VTT to SRT conversion to cover various scenarios.

* Add tests in `tests/test_convert_file.py` for VTT files with different timestamp formats, special characters and symbols, multiple languages, and overlapping timestamps.
* Add tests in `tests/test_convert_directory.py` for directories containing VTT files with different timestamp formats, special characters and symbols, multiple languages, and overlapping timestamps.
* Add tests in `tests/test_vtt_to_str.py` for the `VttToStr` class to handle VTT files with different timestamp formats, special characters and symbols, multiple languages, and overlapping timestamps.

